### PR TITLE
Go Vendoring Standardization

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,3 +23,6 @@ publish:
     username: $$docker_username
     when:
       branch: master
+script:
+- make test
+- make build

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 %*
 \.#*
 .DS_Store
+
+gearman-load-logger

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,3 @@
-FROM golang:1.5
-RUN apt-get update
-RUN apt-get install -y curl build-essential
-
-# copy source code
-RUN mkdir -p /go/src/github.com/Clever/gearman-load-logger
-ADD . /go/src/github.com/Clever/gearman-load-logger
-
-WORKDIR /go/src/github.com/Clever/gearman-load-logger
-
-RUN go install github.com/Clever/gearman-load-logger
-RUN go build -o /usr/local/bin/gearman-load-logger github.com/Clever/gearman-load-logger
-
+FROM debian:jessie
+COPY bin/gearman-load-logger /usr/local/bin/gearman-load-logger
 CMD ["/usr/local/bin/gearman-load-logger"]

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,8 +1,8 @@
 {
-	"ImportPath": "tmp/384358791",
+	"ImportPath": "github.com/Clever/gearman-load-logger",
 	"GoVersion": "go1.5.1",
 	"Packages": [
-		""
+		"github.com/Clever/gearman-load-logger"
 	],
 	"Deps": [
 		{

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,36 @@
 SHELL := /bin/bash
 PKG := github.com/Clever/gearman-load-logger
-
-.PHONY: test $(PKG)
+PKGS := $(shell go list ./... | grep -v /vendor)
+EXECUTABLE := gearman-load-logger
+.PHONY: test vendor build $(PKG)
 
 GOVERSION := $(shell go version | grep 1.5)
 ifeq "$(GOVERSION)" ""
   $(error must be running Go version 1.5)
 endif
-
 export GO15VENDOREXPERIMENT = 1
 
-test: $(PKG)
-
-$(GOPATH)/bin/golint:
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
 	go get github.com/golang/lint/golint
 
-$(PKG): $(GOPATH)/bin/golint
+GODEP := $(GOPATH)/bin/godep
+$(GODEP):
+	go get -u github.com/tools/godep
+
+build:
+	go build -o bin/$(EXECUTABLE) $(PKG)
+
+test: $(PKGS)
+
+$(PKGS): $(GOLINT)
 	@echo ""
 	@echo "FORMATTING $@..."
-	go get -d -t $@
 	gofmt -w=true $(GOPATH)/src/$@/*.go
 	@echo ""
 	@echo "LINTING $@..."
-	$(GOPATH)/bin/golint $(GOPATH)/src/$@/*.go
+	$(GOLINT) $(GOPATH)/src/$@/*.go
 	@echo ""
-
-
-SHELL := /bin/bash
-PKGS := $(shell go list ./... | grep -v /vendor)
-GODEP := $(GOPATH)/bin/godep
-
-$(GODEP):
-	go get -u github.com/tools/godep
 
 vendor: $(GODEP)
 	$(GODEP) save $(PKGS)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifeq "$(GOVERSION)" ""
 endif
 export GO15VENDOREXPERIMENT = 1
 
+all: test build
+
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,15 @@ $(PKG): $(GOPATH)/bin/golint
 	@echo "LINTING $@..."
 	$(GOPATH)/bin/golint $(GOPATH)/src/$@/*.go
 	@echo ""
+
+
+SHELL := /bin/bash
+PKGS := $(shell go list ./... | grep -v /vendor)
+GODEP := $(GOPATH)/bin/godep
+
+$(GODEP):
+	go get -u github.com/tools/godep
+
+vendor: $(GODEP)
+	$(GODEP) save $(PKGS)
+	find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X # remove any nested vendor directories

--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ Note that you can usually rely on the default values of 4730 for the gearman por
 `gearman-load-logger` uses [gearadmin](https://github.com/Clever/gearadmin) and [kayvee](https://github.com/Clever/kayvee), and requires `golang` to be installed (tested with version `1.3`).
 
 However, it is easiest to just download from the [releases page](https://github.com/Clever/gearman-load-logger/releases).
+
+## Changing Dependencies
+
+### New Packages
+
+When adding a new package, you can simply use `make vendor` to update your imports.
+This should bring in the new dependency that was previously undeclared.
+The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
+
+### Existing Packages
+
+First ensure that you have your desired version of the package checked out in your `$GOPATH`.
+
+When to change the version of an existing package, you will need to use the godep tool.
+You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
+So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
+
+```
+# depending on github.com/Clever/foo
+godep update github.com/Clever/foo
+
+# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
+godep update github.com/Clever/foo/a github.com/Clever/foo/b
+```
+

--- a/README.md
+++ b/README.md
@@ -27,27 +27,6 @@ Note that you can usually rely on the default values of 4730 for the gearman por
 
 However, it is easiest to just download from the [releases page](https://github.com/Clever/gearman-load-logger/releases).
 
-## Changing Dependencies
+## Vendoring
 
-### New Packages
-
-When adding a new package, you can simply use `make vendor` to update your imports.
-This should bring in the new dependency that was previously undeclared.
-The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
-
-### Existing Packages
-
-First ensure that you have your desired version of the package checked out in your `$GOPATH`.
-
-When to change the version of an existing package, you will need to use the godep tool.
-You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
-So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
-
-```
-# depending on github.com/Clever/foo
-godep update github.com/Clever/foo
-
-# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
-godep update github.com/Clever/foo/a github.com/Clever/foo/b
-```
-
+Please view the [dev-handbook for instructions](https://github.com/Clever/dev-handbook/blob/master/golang/godep.md).


### PR DESCRIPTION
This PR was mostly autogenerated.

Changes to expect:
- removal of `*_test.go` files in /vendor
- addition of non go files in /vendor
- addtions to README.md & Makefile

**Before your merge!**:
- Please carefully check the Makefile changes
- Ensure that the build is passing
- Check that drone is using the proper image (Clever/drone-go:1.5)

Feel free to ping @natebrennand or #golang for clarification or help.

If you'd like more of an explanation please join us in #golang.
