### PR TITLE
log env & filter down to only production env

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -2,6 +2,7 @@ routes:
   WorkersTotal:
     matchers:
       title: ["total_workers"]
+      env: ["production"]
     output:
       type: "alerts"
       series: "WorkersTotal"
@@ -11,6 +12,7 @@ routes:
   WorkersAvailable:
     matchers:
       title: ["total_workers"]
+      env: ["production"]
     output:
       type: "alerts"
       series: "WorkersAvailable"

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"time"
 
 	"github.com/Clever/discovery-go"
@@ -16,7 +17,8 @@ const (
 )
 
 var (
-	lg = logger.New("gearman-load-logger")
+	lg        = logger.New("gearman-load-logger")
+	deployEnv = os.Getenv("_DEPLOY_ENV")
 )
 
 func logMetrics(g gearadmin.GearmanAdmin) {
@@ -29,6 +31,7 @@ func logMetrics(g gearadmin.GearmanAdmin) {
 			"function":          status.Function,
 			"running_workers":   status.Running,
 			"available_workers": status.AvailableWorkers,
+			"env":               deployEnv,
 		})
 	}
 }


### PR DESCRIPTION
Apparently if we want to filter down to only a single env we need to include it in our log. Discussed w/ oncall-infra and this was the suggested route to take.