### PR TITLE
add workers running gauge

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -19,3 +19,13 @@ routes:
       stat_type: "gauge"
       value_field: "available_workers"
       dimensions: ["function"]
+  WorkersRunning:
+    matchers:
+      title: ["total_workers"]
+      deploy_env: ["production"]
+    output:
+      type: "alerts"
+      series: "WorkersRunning"
+      stat_type: "gauge"
+      value_field: "running_workers"
+      dimensions: ["function"]


### PR DESCRIPTION
Lets us recreate https://metrics.int.clever.com/dashboard/db/gearman-stats in signalfx, and remove all of log-router's gearman-related routing to influxdb
